### PR TITLE
fix: added support for older magister versions

### DIFF
--- a/src/Magister/Services/Foundation/Bootstrap/MakeReplacements.php
+++ b/src/Magister/Services/Foundation/Bootstrap/MakeReplacements.php
@@ -20,7 +20,11 @@ class MakeReplacements
     public function bootstrap(Magister $app)
     {
         if ($app->auth->check()) {
-            $app->config->replace('url', 'id', $app->auth->id());
+            if (is_null($app->auth->id()) && !is_null($app->auth->user())) {                
+                $app->config->replace('url', 'id', $app->auth->user()->Id);                
+            } else {
+                $app->config->replace('url', 'id', $app->auth->id());
+            }
             $app->config->replace('url', 'enrollment', Enrollment::current()->Id);
         }
     }


### PR DESCRIPTION
In my current project i am stuck between two versions of your package, since i connect to multiple schools with my applications, which all have a different version of magister. 

So with this change you will also support the older versions < 1.6.8.